### PR TITLE
feat: setup wizard

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,8 +19,15 @@ services:
       DNS_DISCOVERY_URL: ""
       LOG_LEVEL: DEBUG
       MAX_CONNECTIONS: 150
-      STORE_MESSAGE_RETENTION_POLICY: 2592000
+      PRIVACY: custom
+      WAKUNODE2_AGENT_STRING: nwaku_on_dappnode
       RANDOMIZE_ADDRESS: "true"
+      EXPERIMENTAL_FEATURES: "false"
+      WAKUNODE2_STORE: "false"
+      WAKUNODE2_STORE_MESSAGE_DB_URL: "sqlite:///data/store.sqlite3"
+      WAKUNODE2_STORE_MESSAGE_RETENTION_POLICY: "time:2592000"
+      WAKUNODE2_FILTER: "false"
+      WAKUNODE2_LIGHTPUSH: "false"
       NETWORK: wakuv2.prod
       EXTRA_OPTS: ""
     restart: unless-stopped

--- a/nwaku/entrypoint.sh
+++ b/nwaku/entrypoint.sh
@@ -1,19 +1,5 @@
 #!/bin/bash
 
-# If RANDOMIZE_ADDRESS is set to false, use the same address every time
-# If identity.pem does not exist, generate a new one
-if [ "${RANDOMIZE_ADDRESS}" = "false" ]; then
-    if [ ! -f /data/identity.pem ]; then
-        echo "Generating new identity"
-        # Generate new identity using openssl
-        /usr/bin/openssl ecparam -name secp256k1 -genkey -noout -out /data/identity.pem
-    fi
-    # Extract 32 byte private key from identity.pem
-    _PRIVATE_KEY=$(cat /data/identity.pem | /usr/bin/openssl ec -text -noout | grep priv -A 3 | tail -n +2 | tr -d '\n[:space:]:' | xxd -r -p | xxd -p -c 32)
-    # Set environment variable WAKUNODEV2_NODEKEY to private key
-    export WAKUNODE2_NODEKEY=${_PRIVATE_KEY}
-fi
-
 # If DNS_DISCOVERY_URL is not set, use NETWORK to determine which DNS discovery URL to use
 # NETWORK may be wakuv2.prod, wakuv2.test, status.prod or status.test
 if [ -z "${DNS_DISCOVERY_URL}" ]; then
@@ -39,11 +25,57 @@ else
     export WAKUNODE2_DNS_DISCOVERY_URL=${DNS_DISCOVERY_URL}
 fi
 
+# If PRIVACY is set to paranoid, disable the agent string
+if [ "${PRIVACY}" = "paranoid" ]; then
+    unset WAKUNODE2_AGENT_STRING
+else
+    # If RANDOMIZE_ADDRESS is set to false use the same address every time. 
+    # If identity.pem does not exist, generate a new one
+    if [ "${RANDOMIZE_ADDRESS}" = "false" ]; then
+        if [ ! -f /data/identity.pem ]; then
+            echo "Generating new identity"
+            # Generate new identity using openssl
+            /usr/bin/openssl ecparam -name secp256k1 -genkey -noout -out /data/identity.pem
+        fi
+        # Extract 32 byte private key from identity.pem
+        _PRIVATE_KEY=$(cat /data/identity.pem | /usr/bin/openssl ec -text -noout | grep priv -A 3 | tail -n +2 | tr -d '\n[:space:]:' | xxd -r -p | xxd -p -c 32)
+        # Set environment variable WAKUNODE2_NODEKEY to private key
+        export WAKUNODE2_NODEKEY=${_PRIVATE_KEY}
+    fi
+fi
+
+# If EXPERIMENTAL_FEATURES is set to true
+if [ "${EXPERIMENTAL_FEATURES}" = "true" ]; then
+    # If WAKUNODE2_LIGHTPUSH is set to true, set to 1
+    if [ "${WAKUNODE2_LIGHTPUSH}" = "true" ]; then
+        export WAKUNODE2_LIGHTPUSH=1
+    else
+        unset WAKUNODE2_LIGHTPUSH
+    fi
+
+    # If WAKUNODE2_FILTER is set to true, set to 1
+    if [ "${WAKUNODE2_FILTER}" = "true" ]; then
+        export WAKUNODE2_FILTER=1
+    else
+        unset WAKUNODE2_FILTER
+    fi
+
+    # If WAKUNODE2_STORE is set to true, set to 1
+    if [ "${WAKUNODE2_STORE}" = "true" ]; then
+        export WAKUNODE2_STORE=1
+    else
+        # unset all environment variables start withing WAKUNODE2_STORE prefix
+        unset WAKUNODE2_STORE WAKUNODE2_STORE_MESSAGE_RETENTION_POLICY WAKUNODE2_STORE_MESSAGE_DB_URL
+    fi
+else
+    # unset all environment variables start withing WAKUNODE2 prefix excluding WAKUNODE2_DNS_DISCOVERY_URL
+    # if EXPERIMENTAL_FEATURES is set to false
+    unset WAKUNODE2_LIGHTPUSH WAKUNODE2_FILTER 
+    unset WAKUNODE2_STORE WAKUNODE2_STORE_MESSAGE_RETENTION_POLICY WAKUNODE2_STORE_MESSAGE_DB_URL
+fi
+
 # Execute passing in public IP address and domain
 exec /usr/bin/wakunode --relay=true \
-    --filter=true \
-    --lightpush=true \
-    --store=true \
     --rpc-admin=true \
     --keep-alive=true \
     --max-connections=${MAX_CONNECTIONS:-150} \
@@ -58,8 +90,6 @@ exec /usr/bin/wakunode --relay=true \
     --metrics-server=True \
     --metrics-server-port=9090 \
     --metrics-server-address=0.0.0.0 \
-    --store-message-db-url:sqlite:///data/store.sqlite3 \
-    --store-message-retention-policy:time:${STORE_MESSAGE_RETENTION_POLICY:-2592000} \
     --nat=extip:${_DAPPNODE_GLOBAL_PUBLIC_IP} \
     --dns4-domain-name=nwaku.${_DAPPNODE_GLOBAL_DOMAIN} \
     ${EXTRA_OPTS}

--- a/setup-wizard.yml
+++ b/setup-wizard.yml
@@ -15,6 +15,33 @@ fields:
       - "wakuv2.test"
       - "status.test"
       - "status.prod"
+  - title: Privacy settings
+    id: privacy
+    description: >-
+      Waku is designed to be a privacy-preserving protocol. The user can selectively enable privacy features. On dappnode, by 
+      default a custom level of privacy is enabled (notably the `agent-string` is set to `nwaku_on_dappnode`).
+
+      The `paranoid` level of privacy will disable the `agent-string` and will randomize the node address each time it starts. 
+      The `paranoid` level of privacy is recommended for users who wish to maximize their privacy.
+    target:
+      type: environment
+      name: PRIVACY
+      service: nwaku
+    required: true
+    enum:
+      - "paranoid"
+      - "custom"
+  - title: Agent name
+    id: agent-name
+    description: >-
+      By default this dappnode package will set the agent name to `nwaku_on_dappnode`. This allows other nodes on the network to identify this 
+      node as a dappnode node running waku. If you wish to use a different name, specify it here. Optionally, you can set the default nwaku
+      agent name setting this to an empty string (the ndoe will present itself with the agent name `nwaku`).
+    target:
+      type: environment
+      name: WAKUNODE2_AGENT_STRING
+      service: nwaku
+    if: { "privacy": { "enum": [ "custom" ] } }
   - title: Randomize node adddress
     id: randomize-address
     description: >-
@@ -28,3 +55,75 @@ fields:
     enum:
       - "true"
       - "false"
+    if: { "privacy": { "enum": [ "custom" ] } }
+  - title: Experimental features
+    id: experimental-features
+    description: >-
+      By default, this nwaku will enable features only considered stable. If you wish to enable experimental features, select true.
+    target:
+      type: environment
+      name: EXPERIMENTAL_FEATURES
+      service: nwaku
+    required: true
+    enum:
+      - "true"
+      - "false"
+  - title: ⚠️ Filter protocol
+    id: filter
+    description: >-
+      By default, waku will not enable the [filter protocol](https://rfc.vac.dev/spec/12/). If you wish to enable the filter protocol, select true.
+    target:
+      type: environment
+      name: WAKUNODE2_FILTER
+      service: nwaku
+    required: true
+    enum:
+      - "true"
+      - "false"
+    if: { "experimental-features": { "enum": [ "true" ] } }
+  - title: ⚠️ Store protocol
+    id: store
+    description: >-
+      By default, waku will not enable the [store protocol](https://rfc.vac.dev/spec/13/). If you wish to enable the store protocol, select true.
+    target:
+      type: environment
+      name: WAKUNODE2_STORE
+      service: nwaku
+    required: true
+    enum:
+      - "true"
+      - "false"
+    if: { "experimental-features": { "enum": [ "true" ] } }
+  - title: "⚠️ Store: Message database URL"
+    id: store-message-database-url
+    description: >-
+      By default, waku will use an in-memory database for storing messages. If you wish to use a different database, specify the URL here.
+    target:
+      type: environment
+      name: WAKUNODE2_STORE_MESSAGE_DB_URL
+      service: nwaku
+    required: true
+    if: { "store": { "enum": [ "true" ] }, "experimental-features": { "enum": [ "true" ] } }
+  - title: "⚠️ Store: Message retention policy"
+    id: message-retention-policy
+    description: >-
+      By default, waku will store messages for 2 days. If you wish to enable the message retention policy, select true.
+    target:
+      type: environment
+      name: WAKUNODE2_STORE_MESSAGE_RETENTION_POLICY
+      service: nwaku
+    required: true
+    if: { "store": { "enum": [ "true" ] }, "experimental-features": { "enum": [ "true" ] } }
+  - title: ⚠️ Light Push protocol
+    id: lightpush
+    description: >-
+      By default, waku will not enable the [light push protocol](https://rfc.vac.dev/spec/19/). If you wish to enable the light push protocol, select true.
+    target:
+      type: environment
+      name: WAKUNODE2_LIGHTPUSH
+      service: nwaku
+    required: true
+    enum:
+      - "true"
+      - "false"
+    if: { "experimental-features": { "enum": [ "true" ] } }


### PR DESCRIPTION
This PR:

1. Uses `wakunode` defaults with respect to which protocols to load (only loads `relay` by default).
2. Allows an easy "privacy paranoid" mode for the user to set the best recommendation for privacy preserving features.
3. Configures a default agent-string if privacy isn't `paranoid`.
4. Setup-wizard expansion.