### PR TITLE
fix: connected peers metric

### DIFF
--- a/waku-single-node-grafana-dashboard.json
+++ b/waku-single-node-grafana-dashboard.json
@@ -311,14 +311,14 @@
           },
           "editorMode": "builder",
           "exemplar": true,
-          "expr": "waku_connected_peers{}",
+          "expr": "libp2p_pubsub_peers{instance=\"nwaku.nwaku.public.dappnode:9090\"}",
           "interval": "",
-          "legendFormat": "{{direction}}",
+          "legendFormat": "Peers",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Inbound/Outbound Connected Peers",
+      "title": "Connected Peers",
       "type": "timeseries"
     },
     {
@@ -1193,12 +1193,12 @@
     "list": []
   },
   "time": {
-    "from": "now-6h",
+    "from": "now-12h",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "",
   "title": "nwaku single node dashboard",
   "uid": "nwaku-public-Vcx3GJ2Vk",
-  "version": 4
+  "version": 5
 }


### PR DESCRIPTION
This PR:

1. Changes the metrics used for the connected peers component in the Grafana dashboard. This is due to an upstream issue being tracked at https://github.com/waku-org/nwaku/issues/1503