### PR TITLE
nwaku native websockets and docs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,8 +3,8 @@ on:
   pull_request:
   push:
     branches:
-      - "main"
       - "master"
+      - "main"
       - "v[0-9]+.[0-9]+.[0-9]+"
     paths-ignore:
       - "README.md"
@@ -16,7 +16,7 @@ jobs:
     if: github.event_name != 'push'
     steps:
       - uses: actions/checkout@v2
-      - run: npx @dappnode/dappnodesdk build --skip_save --timeout 2h
+      - run: npx @dappnode/dappnodesdk build --skip_save
 
   release:
     name: Release
@@ -25,7 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Publish
-        run: npx @dappnode/dappnodesdk publish patch --github-release --eth_provider=${{ secrets.ETH_PROVIDER }} --content_provider=pinata --timeout 2h
+        run: npx @dappnode/dappnodesdk publish patch --dappnode_team_preset --content_provider=pinata
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PINATA_API_KEY: ${{ secrets.PINATA_API_KEY }}

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -4,7 +4,7 @@ If you are running your DAppNode within a network that has a UPnP compatible rou
 
 * TCP/UDP Port 60000 (nwaku P2P)
 * UDP Port 9005 (discovery)
-* TCP Port 443 (websockets, see [External access](#External-access) below)
+* TCP Port 443 (websockets, see *External access* below)
 
 ### External access
 

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -22,3 +22,4 @@ Sites that may be of interest:
 
 * [Use Waku in Your Application](https://waku.org/platform)
 * [Examples](https://examples.waku.org)
+* [Psst, have you heard of Waku?](https://mirror.xyz/mfw78.eth/oEcvxycn1V5i1CUPiUdHcXTIZRgYunHHd-gz2LhySNE)

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ This makes it ideal for running a p2p protocol on mobile, or in other similarly 
 By default, the following is enabled when the user installs the package:
 
 1. `relay` enabled (default per `nwaku` binary).
-2. `PubSub` topic set to as dappnode package default to `/waku/2/dev-waku/proto`. May be customised further in [package configuration](http://my.dappnode/#/packages/nwaku.dnp.dappnode.eth/config).
+2. `PubSub` topic set to `/waku/2/dev-waku/proto` as default for dappnode package. May be customised further in [package configuration](http://my.dappnode/#/packages/nwaku.dnp.dappnode.eth/config).
 2. Secure websockets, with automatic SSL provision using dappnodes HTTPS proxy.
 
 Optionally, through the setup-wizard, the user may enable `filter`, `lightpush` and `store` protocols.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ This makes it ideal for running a p2p protocol on mobile, or in other similarly 
 By default, the following is enabled when the user installs the package:
 
 1. `relay` enabled (default per `nwaku` binary).
+2. `PubSub` topic set to as dappnode package default to `/waku/2/dev-waku/proto`. May be customised further in [package configuration](http://my.dappnode/#/packages/nwaku.dnp.dappnode.eth/config).
 2. Secure websockets, with automatic SSL provision using dappnodes HTTPS proxy.
 
 Optionally, through the setup-wizard, the user may enable `filter`, `lightpush` and `store` protocols.

--- a/README.md
+++ b/README.md
@@ -39,19 +39,18 @@ For bleeding edge protocols, such as `RLN`, the user may configure these via the
 ### Containers
 
 1. `nwaku` - the core package containing the daemon. This container inherits from the upstream found on [docker hub](https://hub.docker.com/r/statusteam/nim-waku) and provides minor modifications, notably including `openssl` and an `entrypoint.sh` script to facilitate automatic configuration based on the user's settings from the package's setup wizard.
-2. `websockify` - A simple websockets wrapper for arbitrary TCP connections.
 
 ### Websockets
 
 By default, dappnode comes installed with the `HTTPS` package, which occupies port `443`, therefore exporting port `443` is not a viable option by default. Fortunately `HTTPS` is an NGINX proxy that is able to be dynamically configured to forward DNS-scoped requests to a nominated package. As such, any external secure websockets connections take the following path:
 
-`Cloud --> NGINX Proxy (HTTPS package, SSL enabled, port 443) --> websockify (nwaku package, non-SSL, port 80) --> nwaku (nwaku package, port 60000)`
+`Cloud --> NGINX Proxy (HTTPS package, SSL enabled, port 443) --> nwaku (nwaku package, non-SSL, port 8000)`
 
 By configuring an `exposable` port in the dappnode package's configuration, dappnode will automatically:
 
 1. Acquire a dyndns hostname for DNS resolution to it's external IP address.
 2. Acquire a wildcard SSL certificate from LetsEncrypt, removing this package's requirement to deal with PKI management, greatly simplifying the structure.
-3. Handle SSL termination on NGINX, and forward the encapsulated stream to the nominated destination (websockify).
+3. Handle SSL termination on NGINX, and forward the encapsulated stream to the nominated destination (nwaku).
 
 While a lot of effort to go to, secure websockets accessed from a site delivered via HTTPS require:
 

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -44,8 +44,8 @@
     {
       "name": "nwaku",
       "description": "Waku node and protocol",
-      "serviceName": "websockify",
-      "port": 80,
+      "serviceName": "nwaku",
+      "port": 8000,
       "fromSubdomain": "nwaku"
     }
   ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,5 @@
 version: "3.5"
 services:
-  websockify:
-    image: "statusteam/websockify:v0.10.0"
-    command:
-      - "80"
-      - "nwaku.nwaku.dappnode:60000"
   nwaku:
     image: "nwaku.nwaku.dnp.dappnode.eth:0.1.0"
     build:
@@ -17,7 +12,7 @@ services:
       - "9005:9005/udp"
     environment:
       DNS_DISCOVERY_URL: ""
-      LOG_LEVEL: DEBUG
+      LOG_LEVEL: INFO
       MAX_CONNECTIONS: 150
       PRIVACY: custom
       WAKUNODE2_AGENT_STRING: nwaku_on_dappnode

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,7 @@ services:
       WAKUNODE2_STORE_MESSAGE_RETENTION_POLICY: "time:2592000"
       WAKUNODE2_FILTER: "false"
       WAKUNODE2_LIGHTPUSH: "false"
+      WAKUNODE2_TOPICS: /waku/2/dev-waku/proto
       NETWORK: wakuv2.prod
       EXTRA_OPTS: ""
     restart: unless-stopped

--- a/nwaku/entrypoint.sh
+++ b/nwaku/entrypoint.sh
@@ -92,4 +92,5 @@ exec /usr/bin/wakunode --relay=true \
     --metrics-server-address=0.0.0.0 \
     --nat=extip:${_DAPPNODE_GLOBAL_PUBLIC_IP} \
     --dns4-domain-name=nwaku.${_DAPPNODE_GLOBAL_DOMAIN} \
+    --websocket-support=true \
     ${EXTRA_OPTS}

--- a/setup-wizard.yml
+++ b/setup-wizard.yml
@@ -15,6 +15,18 @@ fields:
       - "wakuv2.test"
       - "status.test"
       - "status.prod"
+  - title: PubSub Topic
+    id: pubsub-topic
+    description: >-
+      By default in this package, nwaku will subscribe to the `/waku/2/dev-waku/proto` topic. This topic is designed for development purposes and 
+      should have lower bandwidth requirements than nwaku's default topic (though there are **no guarantees** that this is the case). If you wish to
+      subscribe nwaku's default topic, set this to an empty string. If you wish to subscribe to a different topic, specify it here, or specify multiple
+      topics separated by space/s.
+    target:
+      type: environment
+      name: WAKUNODE2_TOPICS
+      service: nwaku
+    required: true
   - title: Privacy settings
     id: privacy
     description: >-


### PR DESCRIPTION
This PR:

1. Removes `websockify`, and uses the native websockets (cleartext) within `nwaku` for serving `js-waku` / Websockets clients.
2. Makes minor editorial adjustments to the `GETTING_STARTED.md`.
3. Sets the dappnode team preset in the hope that it automatically creates commented transactions for signing.