### PR TITLE
Update docker hub repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ For bleeding edge protocols, such as `RLN`, the user may configure these via the
 
 ### Containers
 
-1. `nwaku` - the core package containing the daemon. This container inherits from the upstream found on [docker hub](https://hub.docker.com/r/statusteam/nim-waku) and provides minor modifications, notably including `openssl` and an `entrypoint.sh` script to facilitate automatic configuration based on the user's settings from the package's setup wizard.
+1. `nwaku` - the core package containing the daemon. This container inherits from the upstream found on [docker hub](https://hub.docker.com/r/wakuorg/nwaku) and provides minor modifications, notably including `openssl` and an `entrypoint.sh` script to facilitate automatic configuration based on the user's settings from the package's setup wizard.
 
 ### Websockets
 

--- a/nwaku/Dockerfile
+++ b/nwaku/Dockerfile
@@ -1,6 +1,6 @@
 ARG UPSTREAM_VERSION
 
-FROM statusteam/nim-waku:${UPSTREAM_VERSION}
+FROM wakuorg/nwaku:${UPSTREAM_VERSION}
 
 RUN apk add --no-cache bash openssl
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh


### PR DESCRIPTION
* nwaku package will no longer be published as `statusteam/nim-waku` but `wakuorg/nwaku`
* see: https://github.com/waku-org/nwaku/pull/2077